### PR TITLE
Fix modem crashes on LG G2

### DIFF
--- a/rootdir/etc/init.g2.rc
+++ b/rootdir/etc/init.g2.rc
@@ -303,6 +303,12 @@ on boot
     chown system radio /sys/devices/virtual/input/lge_touch/touch_gesture
     chmod 0664 /sys/devices/virtual/input/lge_touch/touch_gesture
 
+    # Subsytem Restart
+    write /sys/bus/msm_subsys/devices/subsys0/restart_level "related"
+    write /sys/bus/msm_subsys/devices/subsys1/restart_level "related"
+    write /sys/bus/msm_subsys/devices/subsys2/restart_level "related"
+    write /sys/bus/msm_subsys/devices/subsys3/restart_level "related"
+    
 on charger
     wait /dev/block/platform/msm_sdcc.1/by-name/modem
     mount vfat /dev/block/platform/msm_sdcc.1/by-name/modem /firmware ro shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337


### PR DESCRIPTION
Fixes modem crashes on LG G2 d803 and other variants.
